### PR TITLE
Issue 9

### DIFF
--- a/docs/BRANCH_RULE.md
+++ b/docs/BRANCH_RULE.md
@@ -1,0 +1,76 @@
+# 作業ルール
+
+## 作業前
+
+1. 作業すべき内容に対して issue を立てる。
+2. 作業をする issue を確認し、その issue 番号を元に`create a branch`から branch を発行する。（例：`issue-1`）
+3. 発行されたコマンドを元にその branch に遷移する。
+
+```bash
+git fetch origin
+git checkout issue-issue番号
+```
+
+## 作業開始
+
+1. 現在のブランチを確認する。
+
+```bash
+git branch
+```
+
+これで作業予定の`* issue/issue番号`と出力されれば、OK。
+もし、作業予定の issue にいない場合は以下のコマンドで想定の branch に遷移する。
+
+```bash
+git switch issue/番号
+```
+
+2. ターミナルから作業ディレクトリに移動し、リモートリポジトリの状態を同期する。
+
+```bash
+git pull origin main
+```
+
+## 作業終了
+
+1. ターミナルから変更点を確認する。
+
+```bash
+git status
+```
+
+変更を行ったファイル名が赤文字で表示される。
+
+2. 作業内容（ファイルや変更）をステージングエリアに追加する。
+
+```bash
+git add .
+```
+
+add を行った後に再び`git status`を行うと赤文字が緑の文字に変更する。
+
+3. ステージングエリアにある変更をコミット（リポジトリの履歴に保存）する。
+
+```bash
+git commit -m "作業内容の端的なコメント"
+```
+
+4. ターミナルから作業ディレクトリに移動し、リモートリポジトリの状態を同期する。 重要！！
+
+```bash
+git pull origin main
+```
+
+5. 変更内容をリモートリポジトリに反映させる。
+
+```bash
+git push origin issue-issue番号
+```
+
+6. プルリクを作成する。
+
+- リモートリポジトリに行き、`Pull requests`タブをクリックする。
+- `New`ボタンを押し、作業を行ったリモートブランチを選択し、`Create pull request`ボタンを選択する。
+- プルリクのタイトル及び概要欄に作業内容を記載する。
+- `Create pull request`ボタンを押した後、**Reviewers**にレビュー担当者を選択する。

--- a/docs/BRANCH_RULE.md
+++ b/docs/BRANCH_RULE.md
@@ -19,11 +19,11 @@ git checkout issue-issue番号
 git branch
 ```
 
-これで作業予定の`* issue/issue番号`と出力されれば、OK。
+これで作業予定の`* issue-issue番号`と出力されれば、OK。
 もし、作業予定の issue にいない場合は以下のコマンドで想定の branch に遷移する。
 
 ```bash
-git switch issue/番号
+git switch issue-番号
 ```
 
 2. ターミナルから作業ディレクトリに移動し、リモートリポジトリの状態を同期する。


### PR DESCRIPTION
## タイトル
docs: BRANCH_RULE.md にブランチ運用手順を整理・明文化

## 概要（What）
GitHub初心者や、ブランチを切って作業した経験がないメンバー向けに、ブランチ運用の手順をドキュメントとして整理しました。  
Issue起票からブランチ作成、作業、push、PR作成までの流れを一連で確認できます。

## 背景（Why）
ブランチを切って作業する手順を明文化し、チーム内で同じ手順を再現できる状態にすることで、認識差分や操作ミスを減らし、チーム開発の質を上げるためです。

## 関連 Issue
Closes #9

## 変更内容
- `docs/BRANCH_RULE.md` にブランチ運用手順を記載
- 「作業前」「作業開始」「作業終了」のフェーズで手順を整理
- それぞれのフェーズに対応するGitコマンド例を追加
- PR作成とレビュー依頼までの流れを明記

## UI / 振る舞いの変更
- ビフォー

  ブランチ運用手順がチーム内で統一されておらず、口頭共有ベースだった。

- アフター

  ブランチ運用手順がドキュメント化され、誰でも同じ流れで作業開始〜PR作成まで実施できる。

## 補足
- 本PRはドキュメント変更のみです（アプリケーションコード変更なし）。