### PR TITLE
データベースの定義

### DIFF
--- a/docs/database-design.md
+++ b/docs/database-design.md
@@ -1,0 +1,142 @@
+# SmartCycle データベース設計
+
+## 1. 概要
+
+| テーブル | 説明 |
+| :--- | :--- |
+| **users** | 利用者情報 |
+| **parking_lots** | 駐輪場マスタ |
+| **devices** | IoT 機器（カメラ／センサー） |
+| **camera_detections** | カメラによる物体検出履歴 |
+| **parking_statuses** | 駐輪場の最新ステータス |
+| **parking_status_histories** | 駐輪場の空き状況履歴 |
+| **reservations** | 利用予約 |
+
+## 2. テーブル定義
+
+### 2.1 users（ユーザー）
+
+既存の実装を継承。
+
+| カラム名 | 型 | 制約 | 説明 |
+| :--- | :--- | :--- | :--- |
+| id | UUID | PRIMARY KEY | UUIDv7 |
+| name | VARCHAR(255) | NOT NULL | ユーザー名 |
+| email | VARCHAR(255) | UNIQUE, NOT NULL | メールアドレス |
+| password_hash | VARCHAR(255) | NOT NULL | ハッシュ化されたパスワード |
+
+### 2.2 parking_lots（駐輪場マスタ）
+
+| カラム名 | 型 | 制約 | 説明 |
+| :--- | :--- | :--- | :--- |
+| id | UUID | PRIMARY KEY | UUIDv7 |
+| name | VARCHAR(255) | NOT NULL | 駐輪場名 |
+| latitude | DOUBLE PRECISION | NOT NULL | 緯度 |
+| longitude | DOUBLE PRECISION | NOT NULL | 経度 |
+| total_spots | INTEGER | NOT NULL | 総収容台数 |
+| price_per_hour | INTEGER | NOT NULL | 時間単価（円） |
+| created_at | TIMESTAMP | DEFAULT NOW() | 登録日時 |
+| updated_at | TIMESTAMP | DEFAULT NOW() | 更新日時 |
+
+### 2.3 devices（デバイス）
+
+駐輪場に設置されるカメラやセンサー。
+
+| カラム名 | 型 | 制約 | 説明 |
+| :--- | :--- | :--- | :--- |
+| id | UUID | PRIMARY KEY | UUIDv7 |
+| parking_lot_id | UUID | FK(parking_lots) | 設置場所 |
+| type | VARCHAR(50) | NOT NULL | `camera`, `sensor` 等 |
+| name | VARCHAR(255) | | デバイス名称 |
+| secret_key | VARCHAR(255) | | デバイス認証用トークン |
+| last_seen_at | TIMESTAMP | | 最終通信確認日時 |
+
+### 2.4 camera_detections（カメラ検出履歴）
+
+| カラム名 | 型 | 制約 | 説明 |
+| :--- | :--- | :--- | :--- |
+| id | UUID | PRIMARY KEY | UUIDv7 |
+| parking_lot_id | UUID | FK(parking_lots) | 駐輪場 ID |
+| device_id | UUID | FK(devices) | 送信元デバイス |
+| detected_count | INTEGER | NOT NULL | 検知された自転車数 |
+| detection_data | JSONB | | 座標などの詳細データ |
+| image_url | VARCHAR(255) | | 画像 URL／パス |
+| created_at | TIMESTAMP | DEFAULT NOW(), INDEX | 検知日時 |
+
+### 2.5 parking_statuses（最新ステータス）
+
+| カラム名 | 型 | 制約 | 説明 |
+| :--- | :--- | :--- | :--- |
+| id | UUID | PRIMARY KEY | UUIDv7 |
+| parking_lot_id | UUID | FK(parking_lots), UNIQUE | 駐輪場 ID |
+| available_spots | INTEGER | NOT NULL | 現在の空き台数 |
+| is_full | BOOLEAN | NOT NULL | 満車フラグ |
+| updated_at | TIMESTAMP | DEFAULT NOW() | 最終更新日時 |
+
+### 2.6 parking_status_histories（ステータス履歴）
+
+| カラム名 | 型 | 制約 | 説明 |
+| :--- | :--- | :--- | :--- |
+| id | UUID | PRIMARY KEY | UUIDv7 |
+| parking_lot_id | UUID | FK(parking_lots) | 駐輪場 ID |
+| available_spots | INTEGER | NOT NULL | 空き台数 |
+| timestamp | TIMESTAMP | DEFAULT NOW(), INDEX | 記録日時 |
+
+### 2.7 reservations（予約）
+
+| カラム名 | 型 | 制約 | 説明 |
+| :--- | :--- | :--- | :--- |
+| id | UUID | PRIMARY KEY | UUIDv7 |
+| user_id | UUID | FK(users) | ユーザー ID |
+| parking_lot_id | UUID | FK(parking_lots) | 駐輪場 ID |
+| start_time | TIMESTAMP | NOT NULL | 開始予定時刻 |
+| end_time | TIMESTAMP | NOT NULL | 終了予定時刻 |
+| status | VARCHAR(50) | NOT NULL | `reserved`, `active`, `completed`, `cancelled` |
+| total_amount | INTEGER | | 利用料金合計 |
+| created_at | TIMESTAMP | DEFAULT NOW() | 予約作成日時 |
+
+## 3. 実装参照（リポジトリ内）
+
+| 種別 | パス |
+| :--- | :--- |
+| Alembic（駐輪場ドメイン） | [server/alembic/versions/20260511_0002_add_parking_domain_tables.py](../server/alembic/versions/20260511_0002_add_parking_domain_tables.py) |
+| Alembic（users） | [server/alembic/versions/20260422_0001_create_users_table.py](../server/alembic/versions/20260422_0001_create_users_table.py) |
+| SQLAlchemy モデル | [server/src/infrastructure/db/models/](../server/src/infrastructure/db/models/) |
+
+実装では `parking_status_histories.timestamp` に対応する ORM 属性名は `recorded_at` です。`reservations` には `end_time > start_time` および `status` の許容値を限定する CHECK 制約が付与されています。
+
+## 4. DB マイグレーション（Alembic）
+
+設定ファイルは [server/alembic.ini](../server/alembic.ini)、環境スクリプトは [server/alembic/env.py](../server/alembic/env.py) です。`DATABASE_URL` は **`postgresql+asyncpg://` で指定して問題ありません**（Alembic 実行時に同期ドライバ `postgresql+psycopg://` へ置き換えられます）。
+
+作業ディレクトリは **`server/`** を前提とします。仮想環境を使う場合は `.venv/bin/alembic`、プロジェクトで `uv` を使う場合は `uv run alembic` を読み替えてください。
+
+### 4.1 よく使うコマンド
+
+PostgreSQL が起動している状態で、接続文字列を環境変数にセットして実行します（値は環境に合わせて変更してください）。
+
+```bash
+cd server
+export DATABASE_URL='postgresql+asyncpg://smartcycle:smartcycle@127.0.0.1:5432/smartcycle'
+```
+
+| 目的 | コマンド |
+| :--- | :--- |
+| 最新リビジョンまで適用 | `alembic upgrade head` |
+| 1 つ前のリビジョンに戻す | `alembic downgrade -1` |
+| 特定リビジョンまで適用 | `alembic upgrade <revision_id>`（例: `alembic upgrade 20260511_0002`） |
+| 特定リビジョンまで戻す | `alembic downgrade <revision_id>`（例: `alembic downgrade 20260422_0001`） |
+| 現在の DB バージョン表示 | `alembic current` |
+| 履歴一覧 | `alembic history` |
+
+実行例（リポジトリ直下の `.venv` を使う場合）:
+
+```bash
+cd server
+DATABASE_URL='postgresql+asyncpg://smartcycle:smartcycle@127.0.0.1:5432/smartcycle' \
+  .venv/bin/alembic upgrade head
+```
+
+### 4.2 Docker Compose 利用時
+
+[docker-compose.yml](../docker-compose.yml) の `backend` サービスは起動時に `alembic upgrade head` を実行する設定になっています。ホストから手動でマイグレーションする場合は、`postgres` をポート公開したうえで `127.0.0.1`（または `localhost`）向けの `DATABASE_URL` を指定してください。コンテナ内から実行する場合はホスト名に `postgres` を使います。

--- a/server/alembic/env.py
+++ b/server/alembic/env.py
@@ -10,8 +10,8 @@ from sqlalchemy.engine import Connection
 # server/ を import ルートにする
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from src.infrastructure.db import models as _models  # noqa: E402, F401
 from src.infrastructure.db.base import Base  # noqa: E402
-from src.infrastructure.db.models import user as _user_model  # noqa: E402, F401
 
 config = context.config
 if config.config_file_name is not None:

--- a/server/alembic/versions/20260511_0002_add_parking_domain_tables.py
+++ b/server/alembic/versions/20260511_0002_add_parking_domain_tables.py
@@ -1,0 +1,181 @@
+"""add parking domain tables
+
+Revision ID: 20260511_0002
+Revises: 20260422_0001
+Create Date: 2026-05-11
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "20260511_0002"
+down_revision = "20260422_0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "parking_lots",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("latitude", sa.Float(), nullable=False),
+        sa.Column("longitude", sa.Float(), nullable=False),
+        sa.Column("total_spots", sa.Integer(), nullable=False),
+        sa.Column("price_per_hour", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=False),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=False),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_parking_lots"),
+    )
+    op.create_table(
+        "devices",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("parking_lot_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("type", sa.String(length=50), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=True),
+        sa.Column("secret_key", sa.String(length=255), nullable=True),
+        sa.Column("last_seen_at", sa.DateTime(timezone=False), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["parking_lot_id"],
+            ["parking_lots.id"],
+            name="fk_devices_parking_lot_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_devices"),
+    )
+    op.create_table(
+        "camera_detections",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("parking_lot_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("device_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("detected_count", sa.Integer(), nullable=False),
+        sa.Column("detection_data", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("image_url", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=False),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["device_id"],
+            ["devices.id"],
+            name="fk_camera_detections_device_id",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["parking_lot_id"],
+            ["parking_lots.id"],
+            name="fk_camera_detections_parking_lot_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_camera_detections"),
+    )
+    op.create_index(
+        "ix_camera_detections_created_at",
+        "camera_detections",
+        ["created_at"],
+        unique=False,
+    )
+    op.create_table(
+        "parking_statuses",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("parking_lot_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("available_spots", sa.Integer(), nullable=False),
+        sa.Column("is_full", sa.Boolean(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=False),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["parking_lot_id"],
+            ["parking_lots.id"],
+            name="fk_parking_statuses_parking_lot_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_parking_statuses"),
+        sa.UniqueConstraint("parking_lot_id", name="uq_parking_statuses_parking_lot_id"),
+    )
+    op.create_table(
+        "parking_status_histories",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("parking_lot_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("available_spots", sa.Integer(), nullable=False),
+        sa.Column(
+            "timestamp",
+            sa.DateTime(timezone=False),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["parking_lot_id"],
+            ["parking_lots.id"],
+            name="fk_parking_status_histories_parking_lot_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_parking_status_histories"),
+    )
+    op.create_index(
+        "ix_parking_status_histories_timestamp",
+        "parking_status_histories",
+        ["timestamp"],
+        unique=False,
+    )
+    op.create_table(
+        "reservations",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("parking_lot_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("start_time", sa.DateTime(timezone=False), nullable=False),
+        sa.Column("end_time", sa.DateTime(timezone=False), nullable=False),
+        sa.Column("status", sa.String(length=50), nullable=False),
+        sa.Column("total_amount", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=False),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint("end_time > start_time", name="ck_reservations_end_after_start"),
+        sa.CheckConstraint(
+            "status IN ('reserved', 'active', 'completed', 'cancelled')",
+            name="ck_reservations_status_allowed",
+        ),
+        sa.ForeignKeyConstraint(
+            ["parking_lot_id"],
+            ["parking_lots.id"],
+            name="fk_reservations_parking_lot_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="fk_reservations_user_id",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_reservations"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("reservations")
+    op.drop_index("ix_parking_status_histories_timestamp", table_name="parking_status_histories")
+    op.drop_table("parking_status_histories")
+    op.drop_table("parking_statuses")
+    op.drop_index("ix_camera_detections_created_at", table_name="camera_detections")
+    op.drop_table("camera_detections")
+    op.drop_table("devices")
+    op.drop_table("parking_lots")

--- a/server/src/infrastructure/db/models/__init__.py
+++ b/server/src/infrastructure/db/models/__init__.py
@@ -1,4 +1,18 @@
 # User 等のモデルを import して Base.metadata を登録する
+from .camera_detection import CameraDetection
+from .device import Device
+from .parking_lot import ParkingLot
+from .parking_status import ParkingStatus
+from .parking_status_history import ParkingStatusHistory
+from .reservation import Reservation
 from .user import User
 
-__all__ = ["User"]
+__all__ = [
+    "CameraDetection",
+    "Device",
+    "ParkingLot",
+    "ParkingStatus",
+    "ParkingStatusHistory",
+    "Reservation",
+    "User",
+]

--- a/server/src/infrastructure/db/models/camera_detection.py
+++ b/server/src/infrastructure/db/models/camera_detection.py
@@ -1,0 +1,38 @@
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..base import Base
+
+
+class CameraDetection(Base):
+    __tablename__ = "camera_detections"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid7,
+    )
+    parking_lot_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("parking_lots.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    device_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("devices.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    detected_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    detection_data: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    image_url: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=False),
+        server_default=text("NOW()"),
+        nullable=False,
+        index=True,
+    )

--- a/server/src/infrastructure/db/models/device.py
+++ b/server/src/infrastructure/db/models/device.py
@@ -1,0 +1,27 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..base import Base
+
+
+class Device(Base):
+    __tablename__ = "devices"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid7,
+    )
+    parking_lot_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("parking_lots.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    type: Mapped[str] = mapped_column(String(50), nullable=False)
+    name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    secret_key: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=False), nullable=True)

--- a/server/src/infrastructure/db/models/parking_lot.py
+++ b/server/src/infrastructure/db/models/parking_lot.py
@@ -1,0 +1,34 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, Integer, String, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..base import Base
+
+
+class ParkingLot(Base):
+    __tablename__ = "parking_lots"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid7,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    latitude: Mapped[float] = mapped_column(Float, nullable=False)
+    longitude: Mapped[float] = mapped_column(Float, nullable=False)
+    total_spots: Mapped[int] = mapped_column(Integer, nullable=False)
+    price_per_hour: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=False),
+        server_default=text("NOW()"),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=False),
+        server_default=text("NOW()"),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/server/src/infrastructure/db/models/parking_status.py
+++ b/server/src/infrastructure/db/models/parking_status.py
@@ -1,0 +1,34 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, UniqueConstraint, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..base import Base
+
+
+class ParkingStatus(Base):
+    __tablename__ = "parking_statuses"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid7,
+    )
+    parking_lot_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("parking_lots.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    available_spots: Mapped[int] = mapped_column(Integer, nullable=False)
+    is_full: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=False),
+        server_default=text("NOW()"),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        UniqueConstraint("parking_lot_id", name="uq_parking_statuses_parking_lot_id"),
+    )

--- a/server/src/infrastructure/db/models/parking_status_history.py
+++ b/server/src/infrastructure/db/models/parking_status_history.py
@@ -1,0 +1,31 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..base import Base
+
+
+class ParkingStatusHistory(Base):
+    __tablename__ = "parking_status_histories"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid7,
+    )
+    parking_lot_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("parking_lots.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    available_spots: Mapped[int] = mapped_column(Integer, nullable=False)
+    recorded_at: Mapped[datetime] = mapped_column(
+        "timestamp",
+        DateTime(timezone=False),
+        server_default=text("NOW()"),
+        nullable=False,
+        index=True,
+    )

--- a/server/src/infrastructure/db/models/reservation.py
+++ b/server/src/infrastructure/db/models/reservation.py
@@ -1,0 +1,45 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Integer, String, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..base import Base
+
+
+class Reservation(Base):
+    __tablename__ = "reservations"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid7,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    parking_lot_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("parking_lots.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    start_time: Mapped[datetime] = mapped_column(DateTime(timezone=False), nullable=False)
+    end_time: Mapped[datetime] = mapped_column(DateTime(timezone=False), nullable=False)
+    status: Mapped[str] = mapped_column(String(50), nullable=False)
+    total_amount: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=False),
+        server_default=text("NOW()"),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        CheckConstraint("end_time > start_time", name="ck_reservations_end_after_start"),
+        CheckConstraint(
+            "status IN ('reserved', 'active', 'completed', 'cancelled')",
+            name="ck_reservations_status_allowed",
+        ),
+    )


### PR DESCRIPTION
## タイトル案

**駐輪場ドメインの DB スキーマ追加・Alembic マイグレーション・設計ドキュメント**

（短縮案: **駐輪場ドメイン DB と Alembic / 設計書の追加**）

---

## 概要

利用者に加え、駐輪場マスタ・IoT デバイス・カメラ検出履歴・最新／履歴ステータス・予約を扱うための PostgreSQL スキーマを追加する。SQLAlchemy モデルと Alembic リビジョン（`20260511_0002`）で定義し、手順とテーブル仕様は [`docs/database-design.md`](docs/database-design.md) にまとめる。

## 変更内容

- **DB / ORM**: `parking_lots`, `devices`, `camera_detections`, `parking_statuses`, `parking_status_histories`, `reservations` のモデル追加（主キーは既存 `users` と同様 UUIDv7）。[`server/src/infrastructure/db/models/__init__.py`](server/src/infrastructure/db/models/__init__.py) でエクスポートを整理。
- **マイグレーション**: [`server/alembic/versions/20260511_0002_add_parking_domain_tables.py`](server/alembic/versions/20260511_0002_add_parking_domain_tables.py) を追加（FK・UNIQUE・インデックス、`reservations` の CHECK 制約を含む）。[`server/alembic/env.py`](server/alembic/env.py) は `Base.metadata` 登録用に `models` 一括 import に変更。
- **ドキュメント**: [`docs/database-design.md`](docs/database-design.md) にテーブル定義・実装参照パス・Alembic コマンド例を記載。

### 同一ブランチに含まれるその他の変更（該当する場合）

- クライアント駐輪場 UI: [`client/src/components/lots/lots.tsx`](client/src/components/lots/lots.tsx)
- IoT 関連 API: [`server/src/modules/iot/api.py`](server/src/modules/iot/api.py)
- EV3 向けスクリプト・README: [`server/scripts/`](server/scripts/)
- [`server/Dockerfile`](server/Dockerfile)、[`server/pyproject.toml`](server/pyproject.toml)、[`server/uv.lock`](server/uv.lock)

## マイグレーション

PostgreSQL 起動後、`server/` で `DATABASE_URL`（例: `postgresql+asyncpg://...`）を設定し、`alembic upgrade head` を実行する。詳細は [`docs/database-design.md`](docs/database-design.md) の「4. DB マイグレーション（Alembic）」を参照。

## レビュー観点

- FK の `ON DELETE`（駐輪場 CASCADE、デバイス削除時は検出履歴 RESTRICT、ユーザーは予約 RESTRICT 等）がプロダクト方針と合うか。
- `reservations` の CHECK（終了時刻 &gt; 開始時刻、`status` の四値）で十分か、将来のステータス追加時の運用。